### PR TITLE
fix: freeze typer from < 0.12.4 until issue is solved

### DIFF
--- a/client-base/environment.yml
+++ b/client-base/environment.yml
@@ -11,5 +11,5 @@ dependencies:
   - python-dotenv
   - python-multipart
   - rich
-  # Exclude version 0.12.4 of typer: https://github.com/DIRACGrid/diracx/issues/280
-  - typer!=0.12.4
+  # Exclude version >= 0.12.4 of typer: https://github.com/DIRACGrid/diracx/issues/280
+  - typer<0.12.4

--- a/server-base/environment.yml
+++ b/server-base/environment.yml
@@ -42,8 +42,8 @@ dependencies:
   - requests
   - rich
   - sqlalchemy
-  # Exclude version 0.12.4 of typer: https://github.com/DIRACGrid/diracx/issues/280
-  - typer!=0.12.4
+  # Exclude version >= 0.12.4 of typer: https://github.com/DIRACGrid/diracx/issues/280
+  - typer<0.12.4
   - uvicorn
   - aiobotocore >=2.12
   - botocore

--- a/services-base/environment.yml
+++ b/services-base/environment.yml
@@ -26,5 +26,6 @@ dependencies:
   - opentelemetry-instrumentation-fastapi
   - opentelemetry-instrumentation-logging
   - opentelemetry-sdk
-  # Exclude version 0.12.4 of typer: https://github.com/DIRACGrid/diracx/issues/280
-  - typer!=0.12.4
+  # Exclude version >= 0.12.4 of typer: https://github.com/DIRACGrid/diracx/issues/280
+  # typer should not be part of services-base, once typer is unfrozen, it should be removed from here
+  - typer<0.12.4


### PR DESCRIPTION
typer `0.12.5` was released yesterday and fixed an issue from April.