### PR TITLE
feat: create lhcbdiracx-services image with oracle instant client

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,21 @@ jobs:
           mkdir output-services-base
           tar -C output-services-base -xf output-services-base.tar
 
+      - name: Build lhcbdiracx-services-base
+        uses: docker/build-push-action@v6
+        with:
+          context: lhcbdiracx-services-base
+          build-contexts: |
+            ghcr.io/diracgrid/diracx/services-base=oci-layout://output-base@${{steps.build_base.outputs.digest}}
+          outputs: type=oci,dest=output-lhcbdiracx-services-base.tar
+          tags: registry.cern.ch/lhcbdiracx/lhcbdiracx-services-base:latest
+          platforms: linux/amd64,linux/arm64
+
+      - name: Extract lhcbdiracx-services-base
+        run: |
+          mkdir output-lhcbdiracx-services-base
+          tar -C output-lhcbdiracx-services-base -xf output-lhcbdiracx-services-base.tar
+
       - name: Build client-base
         uses: docker/build-push-action@v6
         with:
@@ -118,5 +133,10 @@ jobs:
 
           for image_name in base services-base client-base; do
             image_repo=ghcr.io/diracgrid/diracx/${image_name}
+            oras cp --from-oci-layout "$PWD/output-${image_name}:latest" "${image_repo}:latest,${image_version}"
+          done
+
+          for image_name in lhcbdiracx-services-base; do
+            image_repo=registry.cern.ch/lhcbdiracx/${image_name}
             oras cp --from-oci-layout "$PWD/output-${image_name}:latest" "${image_repo}:latest,${image_version}"
           done

--- a/lhcbdiracx-services-base/Dockerfile
+++ b/lhcbdiracx-services-base/Dockerfile
@@ -1,0 +1,16 @@
+FROM ghcr.io/diracgrid/diracx/services-base
+EXPOSE 8000
+
+# Copying in ENTRYPOINT script and environment specification
+COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/
+
+RUN micromamba install --freeze-installed --yes --file /tmp/environment.yml  --name=base && \
+    micromamba clean --all --yes --force-pkgs-dirs && \
+    rm -rf /tmp/environment.yml
+
+# In many clusters the container is ran as a random uid for security reasons.
+# If we mark the conda directory as group 0 and give it group write permissions
+# then we're still able to manage the environment from inside the container.
+USER 0
+RUN chown -R $MAMBA_USER:0 /opt/conda && chmod -R g=u /opt/conda
+USER $MAMBA_USER

--- a/lhcbdiracx-services-base/environment.yml
+++ b/lhcbdiracx-services-base/environment.yml
@@ -1,0 +1,7 @@
+name: diracx
+channels:
+  - diracgrid
+  - conda-forge
+  - nodefaults
+dependencies:
+  - oracle-instant-client


### PR DESCRIPTION
The image is pushed to a private repository on `repository.cern.ch`

cc @chrisburr 


Todo: 
- [ ] validate image built properly
- [ ] CI variables for pushing to `registry.cern.ch`
- [ ] set env variable pointing to `lib` directory containing oracle instant client library