### PR TITLE
feat: Add uuid-utils into the environment file

### DIFF
--- a/client-base/environment.yml
+++ b/client-base/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - python-multipart
   - rich
   - typer
+  - uuid-utils


### PR DESCRIPTION
Linked to https://github.com/DIRACGrid/diracx/pull/421

Within DIRAC integration tests, `diracx-init-cs` fails because of `uuid-utils` being unknown (see [this](https://github.com/DIRACGrid/diracx/actions/runs/16770959593/job/47485725402?pr=421) action).